### PR TITLE
Add support of cucumber@0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
   },
   "homepage": "https://github.com/mattfritz/protractor-cucumber-framework",
   "dependencies": {
-    "glob": "^6.0.1",
+    "object-assign": "^4.0.1",
     "q": "^1.4.1"
   },
   "peerDependencies": {
-    "cucumber": ">= 0.5 <= 0.8.1"
+    "cucumber": "^0.9.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
-    "cucumber": "^0.8.1",
+    "cucumber": "^0.9.1",
     "httpster": "^1.0.1",
     "protractor": "^2.5.1"
   }


### PR DESCRIPTION
Since v0.9.0, cucumber supports only an object as argument of `Cucumber.Cli.Configuration`. See: https://github.com/cucumber/cucumber-js/blob/master/lib/cucumber/cli.js#L24-L39