### PR TITLE
Fix README: `frameworkPath` only supports relative or absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ exports.config = {
   framework: 'custom',
 
   // path relative to the current config file
-  frameworkPath: 'protractor-cucumber-framework'
+  frameworkPath: require.resolve('protractor-cucumber-framework')
 };
 ```
 


### PR DESCRIPTION
Configuration `frameworkPath` does not support module name. Indeed, in https://github.com/angular/protractor/blob/ddb8584a59343284904676ef6d8db5c1c996b900/lib/configParser.js#L150-L158 it will `path.resolve` the value.