### PR TITLE
Use Cucumber.Cli to run features

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,24 @@ Contributing
 ------------
 
 Pull requests are welcome. Commits should have an appropriate message and be squashed.
+
+For Contributors
+----------------
+Clone the github repository:
+
+    git clone https://github.com/mattfritz/protractor-cucumber-framework
+    cd protractor-cucumber-framework
+    npm install
+
+Start up a selenium server. By default, the tests expect the selenium server to be running at `http://localhost:4444/wd/hub`. A selenium server can be started with `webdriver-manager`.
+
+    node_modules/.bin/webdriver-manager update --standalone
+    node_modules/.bin/webdriver-manager start
+
+The test suite runs against the included test application. Start that up with
+
+    npm start
+
+Then run the tests with
+
+    npm test

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var q = require('q'),
-    assign = require('object-assign'),
     path = require('path'),
-    glob = require('glob');
+    glob = require('glob'),
+    Cucumber = require('cucumber');
 
 /**
  * Execute the Runner's test cases through Cucumber.
@@ -11,146 +11,84 @@ var q = require('q'),
  * @return {q.Promise} Promise resolved with the test results
  */
 exports.run = function(runner, specs) {
-  // TODO - add the event interface for cucumber.
-  var Cucumber = require('cucumber');
-  var configDir = runner.getConfig().configDir;
-
-  // Set up exec options for Cucumber
-  var execOptions = assign({
-    format: [],
-    tags: [],
-    require: [],
-    compiler: []
-  }, runner.getConfig().cucumberOpts);
-
-  ['compiler', 'format', 'tags', 'require'].forEach(function (option) {
-    // Make sure that options values are arrays
-    if (!Array.isArray(execOptions[option])) {
-      execOptions[option] = [ execOptions[option] ];
-    }
-    if (option === 'require') {
-      execOptions[option] =
-        execOptions[option].map(function(path) {
-          // Handle glob matching
-          return glob.sync(path, {cwd: configDir});
-        }).reduce(function(opts, globPaths) {
-          // Combine paths into flattened array
-          return opts.concat(globPaths);
-        }, []).map(function(requirePath) {
-          // Resolve require absolute path
-          return path.resolve(configDir, requirePath)
-        }).filter(function(item, pos, orig) {
-          // Make sure requires are unique
-          return orig.indexOf(item) == pos;
-        });
-    }
-  });
-
-  var testResult = [];
-  var stepResults = {
-    description: null,
-    assertions: [],
-    duration: 0
-  };
-  var scenarioFailed = false;
-
-  var failedCount = 0;
-  // Add a listener into cucumber so that protractor can find out which
-  // steps passed/failed
-  var addResultListener = function(formatter) {
-    var feature = { getName: function() { return ''; } };
-    var originalHandleBeforeFeatureEvent = formatter.handleBeforeFeatureEvent;
-    formatter.handleBeforeFeatureEvent = function(event, callback) {
-      feature = event.getPayloadItem('feature');
-      if (typeof originalHandleBeforeFeatureEvent == 'function') {
-        originalHandleBeforeFeatureEvent.apply(formatter, arguments);
-      } else {
-        callback();
-      }
-    };
-    var originalHandleAfterScenarioEvent = formatter.handleAfterScenarioEvent;
-    formatter.handleAfterScenarioEvent = function(event, callback) {
-      var scenarioInfo = {
-        name: event.getPayloadItem('scenario').getName(),
-        category: feature.getName()
-      };
-      stepResults.description = scenarioInfo.name;
-      if (scenarioFailed) {
-        ++failedCount;
-        runner.emit('testFail', scenarioInfo);
-      } else {
-        runner.emit('testPass', scenarioInfo);
-      }
-
-      testResult.push(stepResults);
-      stepResults = {
-        description: null,
-        assertions: [],
-        duration: 0
-      };
-      scenarioFailed = false;
-
-      if (originalHandleAfterScenarioEvent
-          && typeof(originalHandleAfterScenarioEvent) === 'function') {
-            originalHandleAfterScenarioEvent(event, callback);
-      } else {
-        callback();
-      }
-    };
-
-    var originalHandleStepResultEvent = formatter.handleStepResultEvent;
-    formatter.handleStepResultEvent = function(event, callback) {
-      var stepResult = event.getPayloadItem('stepResult');
-      var isStepFailed = stepResult.getStatus() === Cucumber.Status.FAILED;
-      var isStepSuccessful = stepResult.getStatus() === Cucumber.Status.PASSED;
-
-      if (isStepSuccessful) {
-        stepResults.assertions.push({
-          passed: true
-        });
-        stepResults.duration += stepResult.getDuration();
-      } else if (isStepFailed) {
-        scenarioFailed = true;
-        var failureMessage = stepResult.getFailureException();
-        stepResults.assertions.push({
-          passed: false,
-          errorMsg: failureMessage.message,
-          stackTrace: failureMessage.stack
-        });
-        stepResults.duration += stepResult.getDuration();
-      }
-
-      if (originalHandleStepResultEvent
-          && typeof(originalHandleStepResultEvent) === 'function') {
-            originalHandleStepResultEvent(event, callback);
-      } else {
-        callback();
-      }
-    };
-  };
+  var results = {}
+  require('./lib/runState').initialize(runner, results);
 
   return runner.runTestPreparer().then(function() {
     return q.promise(function(resolve, reject) {
-      var cucumberConf = Cucumber.Cli.Configuration(execOptions, specs);
-      var runtime = Cucumber.Runtime(cucumberConf);
-      var formatters = cucumberConf.getFormatters();
+      var cliArguments = convertOptionsToCliArguments(runner.getConfig().cucumberOpts);
+      cliArguments.push('--require', path.resolve(__dirname, 'lib', 'resultsCapturer.js'));
+      cliArguments = cliArguments.concat(specs);
 
-      addResultListener(formatters[0]);
-      formatters.forEach(runtime.attachListener.bind(runtime));
-
-      runtime.start(function() {
+      Cucumber.Cli(cliArguments).run(function (isSuccessful) {
         try {
           if (runner.getConfig().onComplete) {
             runner.getConfig().onComplete();
           }
-          resolve({
-            failedCount: failedCount,
-            specResults: testResult
-          });
+
+          resolve(results);
         } catch (err) {
           reject(err);
         }
       });
     });
   });
+
+  function convertOptionsToCliArguments(options) {
+    var cliArguments = ['node', 'cucumberjs'];
+
+    for (var option in options) {
+      var cliArgumentValues = convertOptionValueToCliValues(option, options[option]);
+
+      if (cliArgumentValues.length) {
+        cliArgumentValues.forEach(function (value) {
+          cliArguments.push('--' + option, value);
+        });
+      } else {
+        cliArguments.push('--' + option);
+      }
+    }
+
+    return cliArguments;
+  }
+
+  function convertRequireOptionValuesToCliValues(values) {
+    var configDir = runner.getConfig().configDir;
+
+    return values.map(function(path) {
+      // Handle glob matching
+      return glob.sync(path, {cwd: configDir});
+    }).reduce(function(opts, globPaths) {
+      // Combine paths into flattened array
+      return opts.concat(globPaths);
+    }, []).map(function(requirePath) {
+      // Resolve require absolute path
+      return path.resolve(configDir, requirePath)
+    }).filter(function(item, pos, orig) {
+      // Make sure requires are unique
+      return orig.indexOf(item) == pos;
+    });
+  }
+
+  function convertGenericOptionValuesToCliValues(values) {
+    return values.reduce(function (opts, value) {
+      if (value !== true) {
+        opts.push(value);
+      }
+
+      return opts;
+    }, []);
+  }
+
+  function convertOptionValueToCliValues(option, values) {
+    if (!Array.isArray(values)) {
+      values = [values];
+    }
+
+    if (option === 'require') {
+      return convertRequireOptionValuesToCliValues(values);
+    } else {
+      return convertGenericOptionValuesToCliValues(values);
+    }
+  }
 };

--- a/lib/resultsCapturer.js
+++ b/lib/resultsCapturer.js
@@ -1,0 +1,81 @@
+var state = require('./runState');
+var Cucumber = require('cucumber');
+
+function buildStepResults() {
+  return {
+    description: null,
+    assertions: [],
+    duration: 0
+  }
+}
+
+function buildFeature() {
+  return {
+    getName: function() {
+      return '';
+    }
+  };
+}
+
+function clearResults() {
+  state.results.failedCount = 0;
+  state.results.specResults = [];
+}
+
+module.exports = function () {
+  var scenarioFailed = false;
+  var feature = buildFeature();
+  var stepResults = buildStepResults();
+
+  this.registerHandler('BeforeFeatures', function (event, callback) {
+    clearResults();
+    callback();
+  });
+
+  this.registerHandler('BeforeFeature', function (event, callback) {
+    feature = event.getPayloadItem('feature');
+    callback();
+  });
+
+  this.registerHandler('AfterScenario', function (event, callback) {
+    var scenarioInfo = {
+      name: event.getPayloadItem('scenario').getName(),
+      category: feature.getName()
+    };
+    stepResults.description = scenarioInfo.name;
+
+    if (scenarioFailed) {
+      ++state.results.failedCount;
+      state.runner.emit('testFail', scenarioInfo);
+    } else {
+      state.runner.emit('testPass', scenarioInfo);
+    }
+
+    state.results.specResults.push(stepResults);
+    stepResults = buildStepResults();
+    scenarioFailed = false;
+    callback();
+  });
+
+  this.registerHandler('StepResult', function (event, callback) {
+    var stepResult = event.getPayloadItem('stepResult');
+    var isStepFailed = stepResult.getStatus() === Cucumber.Status.FAILED;
+    var isStepSuccessful = stepResult.getStatus() === Cucumber.Status.PASSED;
+
+    if (isStepSuccessful) {
+      stepResults.assertions.push({passed: true});
+      stepResults.duration += stepResult.getDuration();
+    } else if (isStepFailed) {
+      scenarioFailed = true;
+      var failureMessage = stepResult.getFailureException();
+      stepResults.assertions.push({
+        passed: false,
+        errorMsg: failureMessage.message,
+        stackTrace: failureMessage.stack
+      });
+      stepResults.duration += stepResult.getDuration();
+    }
+
+    callback();
+  });
+};

--- a/lib/runState.js
+++ b/lib/runState.js
@@ -1,0 +1,8 @@
+var state = {};
+
+state.initialize = function (runner, results) {
+  state.runner = runner;
+  state.results = results;
+};
+
+module.exports = state;

--- a/spec/cucumber/lib.feature
+++ b/spec/cucumber/lib.feature
@@ -13,3 +13,13 @@ Feature: Running Cucumber with Protractor
   Scenario: Wrapping WebDriver
     Given I go on "index.html"
     Then the title should equal "My AngularJS App"
+
+  @failing
+  Scenario: Report failures
+    Given I go on "index.html"
+    Then the title should equal "Failing scenario 1"
+
+  @failing
+  Scenario: Reporting multiple failures
+    Given I go on "index.html"
+    Then the title should equal "Failing scenario 2"

--- a/test.js
+++ b/test.js
@@ -1,14 +1,28 @@
 #!/usr/bin/env node
 
 var Executor = require('./test_util').Executor;
-
-var passingTests = ['node node_modules/protractor/lib/cli.js spec/cucumberConf.js'];
-
 var executor = new Executor();
 
-passingTests.forEach(function(passing_test) {
-  executor.addCommandlineTest(passing_test)
-      .assertExitCodeOnly();
-});
+testSuccessfulFeatures();
+testFailingFeatures();
+testFailFastFastOption()
 
 executor.execute();
+
+function testSuccessfulFeatures() {
+  executor.addCommandlineTest('node node_modules/protractor/lib/cli.js spec/cucumberConf.js')
+    .expectExitCode(0);
+}
+
+function testFailingFeatures() {
+  executor.addCommandlineTest('node node_modules/protractor/lib/cli.js spec/cucumberConf.js --cucumberOpts.tags @failing')
+    .expectExitCode(1)
+    .expectErrors([{message: "expected 'My AngularJS App' to equal 'Failing scenario 1'"},
+                   {message: "expected 'My AngularJS App' to equal 'Failing scenario 2'"}]);
+}
+
+function testFailFastFastOption() {
+  executor.addCommandlineTest('node node_modules/protractor/lib/cli.js spec/cucumberConf.js --cucumberOpts.tags @failing --cucumberOpts.fail-fast')
+   .expectExitCode(1)
+   .expectErrors({message: "expected 'My AngularJS App' to equal 'Failing scenario 1'"});
+}


### PR DESCRIPTION
This changes the way that cucumber is run to be the same way you would run it from the command line instead of duplicating what `Cli#run` is already doing for us. This way the options are parsed the same way between the two and we get the same default options set, i.e. color (see
https://github.com/cucumber/cucumber-js/pull/457#issuecomment-157792257). This should make it more stable and not break with internal cucumber changes like what we've seen in the past with supporting multiple formatters.

Since the the `Cli` doesn't expose its parsed configuration we can't monkey patch one of the formatters anymore. Instead we tack on an extra `require` to the cli arguments for our own listener that uses the official cucumber events to capture the results.

There's no more special handling of `cucumberOpts` (except `require` for which we do the glob expansion for) so there's a 1-to-1 mapping to the cucumbers cli arguments. For example, the following `cucumberOpts`

```javascript
  cucumberOpts: {
    format: ['json:./build/test-results/protractor.json', 'pretty'],
    require: ['features/step_definitions/**/*.js', 'features/support/**/*.js'],
    'no-source': true,
    strict: true
  },
```

would be converted to the following cucumber command...

```
  cucumberjs \
  --format json:./build/test-results/protractor.json \
  --format pretty \
  --require features/step_definitions/foo.js \
  --require features/step_definitions/bar.js \
  --no-source \
  --strict \
  foo.feature \
  bar.feature
```

This way there _shouldn't_ be any changes needed in this library to support new cucumber options.