### PR TITLE
Filter options that are empty arrays, pass option name if value is boolean true

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,12 +40,12 @@ exports.run = function(runner, specs) {
     for (var option in options) {
       var cliArgumentValues = convertOptionValueToCliValues(option, options[option]);
 
-      if (cliArgumentValues.length) {
+      if (cliArgumentValues === true) {
+        cliArguments.push('--' + option);
+      } else if (cliArgumentValues.length) {
         cliArgumentValues.forEach(function (value) {
           cliArguments.push('--' + option, value);
         });
-      } else {
-        cliArguments.push('--' + option);
       }
     }
 
@@ -71,13 +71,11 @@ exports.run = function(runner, specs) {
   }
 
   function convertGenericOptionValuesToCliValues(values) {
-    return values.reduce(function (opts, value) {
-      if (value !== true) {
-        opts.push(value);
-      }
-
-      return opts;
-    }, []);
+    if (values[0] === true) {
+      return values[0]
+    } else {
+      return values;
+    }
   }
 
   function convertOptionValueToCliValues(option, values) {


### PR DESCRIPTION
This should address issue #10 . It assumes that if a boolean `true` is found in the value for any option, that option name should be passed directly to Cucumber CLI. Options with an empty array for the value are filtered out with a warning logged to the console. For instance, the following cucumberOpts:

    cucumberOpts: {
      require: ['../support/World.js', '../support/PageObjectMap.js'];,
      tags: ['@tag1', '~@tag2']
      emptyArray: [],
      format: 'pretty',
      dryRun: true
    }

would pass the following options to the Cucumber CLI:

    [ 'node',
      'cucumberjs',
      '--require',
      '/Users/nathan.thompson/Projects/personal/cukefarm-template/node_modules/cukefarm/lib/step_definitions/GeneralStepDefs.js',
      '--require',
      '/Users/nathan.thompson/Projects/personal/cukefarm-template/spec/support/World.js',
      '--tags',
      '@tag1',
      '--tags',
      '~@tag2',
      '--format',
      'pretty',
      '--dryRun' ]

and the following messages would show up in the console:

    [...]
    Starting selenium standalone server...
    [launcher] Running 1 instances of WebDriver
    Selenium standalone server started at http://192.168.200.118:62292/wd/hub
    WARNING: emptyArray was an empty array. Skipping this option.
    Feature: Example
    [...]

Let me know if I should make any changes!