### PR TITLE
Should fail if `Cucumber.Cli().run()` results `false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ exports.run = function(runner, specs) {
             runner.getConfig().onComplete();
           }
 
+          if (!isSuccessful) {
+            reject(new Error('Cucumber scenarios failed.'))
+            return
+          }
+
           resolve(results);
         } catch (err) {
           reject(err);

--- a/spec/cucumber/lib.feature
+++ b/spec/cucumber/lib.feature
@@ -23,3 +23,8 @@ Feature: Running Cucumber with Protractor
   Scenario: Reporting multiple failures
     Given I go on "index.html"
     Then the title should equal "Failing scenario 2"
+
+  @strict
+  Scenario: Missing step definition
+    Given I go on "index.html"
+    Then this step is not defined

--- a/test.js
+++ b/test.js
@@ -5,7 +5,8 @@ var executor = new Executor();
 
 testSuccessfulFeatures();
 testFailingFeatures();
-testFailFastFastOption()
+testFailFastFastOption();
+testStrictOption();
 
 executor.execute();
 
@@ -17,13 +18,20 @@ function testSuccessfulFeatures() {
 
 function testFailingFeatures() {
   executor.addCommandlineTest('node node_modules/protractor/lib/cli.js spec/cucumberConf.js --cucumberOpts.tags @failing')
-    .expectExitCode(1)
-    .expectErrors([{message: "expected 'My AngularJS App' to equal 'Failing scenario 1'"},
-                   {message: "expected 'My AngularJS App' to equal 'Failing scenario 2'"}]);
+    .expectExitCode(100)
+    .expectOutput("expected 'My AngularJS App' to equal 'Failing scenario 1'")
+    .expectOutput("expected 'My AngularJS App' to equal 'Failing scenario 2'");
 }
 
 function testFailFastFastOption() {
   executor.addCommandlineTest('node node_modules/protractor/lib/cli.js spec/cucumberConf.js --cucumberOpts.tags @failing --cucumberOpts.fail-fast')
-   .expectExitCode(1)
-   .expectErrors({message: "expected 'My AngularJS App' to equal 'Failing scenario 1'"});
+   .expectExitCode(100)
+   .expectOutput("expected 'My AngularJS App' to equal 'Failing scenario 1'");
+}
+
+function testStrictOption() {
+  executor.addCommandlineTest('node node_modules/protractor/lib/cli.js spec/cucumberConf.js --cucumberOpts.tags @strict --cucumberOpts.strict')
+   .expectExitCode(100)
+   .expectOutput("/^this step is not defined$/")
+   .expectOutput("Error: Cucumber scenarios failed.");
 }


### PR DESCRIPTION
In some case, Cucumber results `false` as first argument of `run()` callback. [`bin/cucumber.js#L4`]
(https://github.com/cucumber/cucumber-js/blob/7cff9b86e1f77b131a335ffc04c4f119f0fff30b/bin/cucumber.js#L4)
Currently, we don't care about it, see [`index.js#L26`](https://github.com/mattfritz/protractor-cucumber-framework/blob/d5d9dc446a3151c6ebaa0a8010a5120283feeca0/index.js#L26)

This is really useful for being able to use the option `strict`. In case of `strict: true`, cucumber will results false when a step is not defined.

This commit changes the way to check `errors` during tests. Since we reject the framework promise, Protractor does not output the JSON results file. So it changes the implementation to check output instead.