### PR TITLE
support for the cucumber 2 rc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+multidep_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ node_js:
   - "7"
 
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3
-  - ./node_modules/.bin/webdriver-manager update
-  - nohup bash -c "./node_modules/.bin/webdriver-manager start 2>&1 &"
-  - nohup bash -c "npm start 2>&1 &"
-  - sleep 3
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+  - ./scripts/webdriver.sh
+  - ./scripts/testserver.sh
 
 script:
   - TEST_BROWSER_NAME=firefox npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - "4"
-  - "5"
+  - "6"
+  - "7"
 
 before_script:
   - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -50,15 +50,14 @@ Clone the github repository:
     cd protractor-cucumber-framework
     npm install
 
-Start up a selenium server. By default, the tests expect the selenium server to be running at `http://localhost:4444/wd/hub`. A selenium server can be started with `webdriver-manager`.
+Start up a selenium server:
 
-    node_modules/.bin/webdriver-manager update --standalone
-    node_modules/.bin/webdriver-manager start
+    npm run webdriver
 
-The test suite runs against the included test application. Start that up with
+Start up the test app that tests will be run against:
 
     npm start
 
-Then run the tests with
+Run the tests:
 
     npm test

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var q = require('q'),
     glob = require('glob'),
     assign = require('object-assign'),
     debug = require('debug')('protractor-cucumber-framework'),
-    Cucumber = require('cucumber'),
+    Cucumber = require('./lib/cucumberLoader').load(),
     state = require('./lib/runState');
 
 /**

--- a/lib/cucumberLoader.js
+++ b/lib/cucumberLoader.js
@@ -1,0 +1,7 @@
+module.exports.load = function() {
+  if (process.env.MULTIDEP_CUCUMBER_VERSION) {
+    return require('multidep')('spec/multidep.js')('cucumber', process.env.MULTIDEP_CUCUMBER_VERSION);
+  } else {
+    return require('cucumber');
+  }
+}

--- a/lib/resultsCapturer.js
+++ b/lib/resultsCapturer.js
@@ -1,5 +1,5 @@
 var state = require('./runState');
-var Cucumber = require('cucumber');
+var Cucumber = require('./cucumberLoader').load();
 
 if (Cucumber.defineSupportCode) {
   Cucumber.defineSupportCode(function(supportCode) {

--- a/lib/resultsCapturer.js
+++ b/lib/resultsCapturer.js
@@ -1,30 +1,16 @@
 var state = require('./runState');
 var Cucumber = require('cucumber');
 
-function buildStepResults() {
-  return {
-    description: null,
-    assertions: [],
-    duration: 0
-  }
+if (Cucumber.defineSupportCode) {
+  Cucumber.defineSupportCode(function(supportCode) {
+    registerHandlers.call(supportCode);
+  });
+} else {
+  module.exports = registerHandlers;
 }
 
-function buildFeature() {
-  return {
-    getName: function() {
-      return '';
-    }
-  };
-}
-
-function clearResults() {
-  state.results.failedCount = 0;
-  state.results.specResults = [];
-}
-
-module.exports = function () {
+function registerHandlers() {
   var scenarioFailed = false;
-  var feature = buildFeature();
   var stepResults = buildStepResults();
 
   this.registerHandler('BeforeFeatures', function (event, callback) {
@@ -32,15 +18,11 @@ module.exports = function () {
     callback();
   });
 
-  this.registerHandler('BeforeFeature', function (event, callback) {
-    feature = event.getPayloadItem('feature');
-    callback();
-  });
-
-  this.registerHandler('AfterScenario', function (event, callback) {
+  this.registerHandler('AfterScenario', function (scenario, callback) {
+    var feature = getter(scenario, 'feature');
     var scenarioInfo = {
-      name: event.getPayloadItem('scenario').getName(),
-      category: feature.getName()
+      name: getter(scenario, 'name'),
+      category: getter(feature, 'name')
     };
     stepResults.description = scenarioInfo.name;
 
@@ -57,16 +39,14 @@ module.exports = function () {
     callback();
   });
 
-  this.registerHandler('StepResult', function (event, callback) {
-    var stepResult = event.getPayloadItem('stepResult');
-
-    switch (stepResult.getStatus()) {
+  this.registerHandler('StepResult', function(stepResult, callback) {
+    switch (getter(stepResult, 'status')) {
       case Cucumber.Status.PASSED:
         stepResults.assertions.push({passed: true});
         break;
       case Cucumber.Status.FAILED:
         scenarioFailed = true;
-        var failureMessage = stepResult.getFailureException();
+        var failureMessage = getter(stepResult, 'failureException');
         stepResults.assertions.push({
           passed: false,
           errorMsg: failureMessage.message,
@@ -84,7 +64,26 @@ module.exports = function () {
         break;
     }
 
-    stepResults.duration += stepResult.getDuration();
+    stepResults.duration += getter(stepResult, 'duration');
     callback();
   });
-};
+}
+
+function buildStepResults() {
+  return {
+    description: null,
+    assertions: [],
+    duration: 0
+  }
+}
+
+function clearResults() {
+  state.results.failedCount = 0;
+  state.results.specResults = [];
+}
+
+function getter(object, property) {
+  var getterFunction = 'get' + property.charAt(0).toUpperCase() + property.slice(1);
+  return object[getterFunction] ? object[getterFunction]() : object[property];
+}
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=6.9.x"
   },
   "scripts": {
+    "webdriver": "webdriver-manager update --standalone && webdriver-manager start",
     "start": "httpster -d testapp/ -p `node -p 'process.env.HTTP_PORT || require(\"./spec/environment\").webServerDefaultPort'`",
     "pretest": "multidep spec/multidep.js",
     "test": "node scripts/test.js"
@@ -43,14 +44,14 @@
   },
   "peerDependencies": {
     "cucumber": ">= 1.3.0",
-    "protractor": ">= 5.0.0"
+    "protractor": ">= 3.0.0"
   },
   "devDependencies": {
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
     "httpster": "1.0.3",
     "multidep": "2.0.2",
-    "protractor": "5.1.1"
+    "protractor": "4.0.14"
   },
   "cucumberConf": {
     "version1": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "protractor-cucumber-framework",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Protractor framework for Cucumber.js",
   "main": "index.js",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "scripts": {
     "start": "httpster -d testapp/ -p `node -p 'process.env.HTTP_PORT || require(\"./spec/environment\").webServerDefaultPort'`",
-    "test": "node test.js"
+    "pretest": "multidep spec/multidep.js",
+    "test": "node scripts/test.js"
   },
   "repository": {
     "type": "git",
@@ -41,10 +45,14 @@
     "cucumber": ">= 0.9.1"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "chai-as-promised": "^5.2.0",
-    "cucumber": "^1.0.0",
-    "httpster": "^1.0.1",
-    "protractor": "^3.2.0"
+    "chai": "3.5.0",
+    "chai-as-promised": "6.0.0",
+    "httpster": "1.0.3",
+    "multidep": "2.0.2",
+    "protractor": "5.1.1"
+  },
+  "cucumberConf": {
+    "version1": "1.3.1",
+    "version2": "2.0.0-rc.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "protractor-cucumber-framework",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Protractor framework for Cucumber.js",
   "main": "index.js",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.9.x"
   },
   "scripts": {
     "start": "httpster -d testapp/ -p `node -p 'process.env.HTTP_PORT || require(\"./spec/environment\").webServerDefaultPort'`",
@@ -42,7 +42,8 @@
     "q": "^1.4.1"
   },
   "peerDependencies": {
-    "cucumber": ">= 0.9.1"
+    "cucumber": ">= 1.3.0",
+    "protractor": ">= 5.0.0"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -9,6 +9,7 @@ testFailFastFastOption();
 testStrictOption();
 testUndefinedWithoutStrictOption();
 testMultiCapsOverrideBaseOptsAndCliOpts();
+testCucumber2();
 
 executor.execute();
 
@@ -49,4 +50,11 @@ function testMultiCapsOverrideBaseOptsAndCliOpts() {
   executor.addCommandlineTest('node_modules/protractor/bin/protractor spec/multiConf.js --cucumberOpts.tags @failing')
    .expectExitCode(0)
    .expectErrors([]);
+}
+
+function testCucumber2() {
+  executor.addCommandlineTest('node_modules/protractor/bin/protractor spec/cucumber2Conf.js')
+    .cucumberVersion2()
+    .expectExitCode(0)
+    .expectErrors([]);
 }

--- a/scripts/test_util.js
+++ b/scripts/test_util.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
-var child_process = require('child_process'),
-    q = require('q'),
-    fs = require('fs');
+var child_process = require('child_process');
+var fs = require('fs');
+var path = require('path');
+var q = require('q');
+
+var cucumberConf = require(path.join(__dirname, '..', 'package.json')).cucumberConf;
 
 var CommandlineTest = function(command) {
   var self = this;
@@ -12,6 +15,12 @@ var CommandlineTest = function(command) {
   this.expectedErrors_ = [];
   this.assertExitCodeOnly_ = false;
   this.expectedOutput_ = [];
+  this.cucumberVesion_ = cucumberConf.version1;
+
+  this.cucumberVersion2 = function() {
+    self.cucumberVesion_ = cucumberConf.version2;
+    return self;
+  };
 
   // If stdioOnlyOnFailures_ is true, do not stream stdio unless test failed.
   // This is to prevent tests with expected failures from polluting the output.
@@ -64,6 +73,8 @@ var CommandlineTest = function(command) {
   };
 
   this.run = function() {
+    process.env.MULTIDEP_CUCUMBER_VERSION = self.cucumberVesion_;
+
     var start = new Date().getTime();
     var testOutputPath = 'test_output_' + start + '.tmp';
     var output = '';

--- a/scripts/testserver.sh
+++ b/scripts/testserver.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+npm run start 2>&1 &
+sleep 3
+echo test application started

--- a/scripts/webdriver.sh
+++ b/scripts/webdriver.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+npm run webdriver 2>&1 &
+sleep 3
+echo webdriver started

--- a/spec/cucumber/lib.feature
+++ b/spec/cucumber/lib.feature
@@ -9,6 +9,11 @@ Feature: Running Cucumber with Protractor
     Then it should still do normal tests
     Then it should expose the correct global variables
 
+  @cucumber2
+  Scenario: Using Cucumber 2
+    Given I go on "index.html"
+    Then the title should equal "My AngularJS App"
+
   @dev
   Scenario: Wrapping WebDriver
     Given I go on "index.html"

--- a/spec/cucumber/stepDefinitions.js
+++ b/spec/cucumber/stepDefinitions.js
@@ -1,41 +1,33 @@
-// Use the external Chai As Promised to deal with resolving promises in
-// expectations.
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
-
 var expect = chai.expect;
 
-// Chai expect().to.exist syntax makes default jshint unhappy.
-// jshint expr:true
-
 module.exports = function() {
+  this.Given(/^I run Cucumber with Protractor$/, function(next) {
+    next();
+  });
 
-    this.Given(/^I run Cucumber with Protractor$/, function(next) {
-        next();
-    });
+  this.Given(/^I go on(?: the website)? "([^"]*)"$/, function(url, next) {
+    browser.get(url);
+    next();
+  });
 
-    this.Given(/^I go on(?: the website)? "([^"]*)"$/, function(url, next) {
-        browser.get(url);
-        next();
-    });
+  this.Then(/^it should still do normal tests$/, function(next) {
+    expect(true).to.equal(true);
+    next();
+  });
 
-    this.Then(/^it should still do normal tests$/, function(next) {
-        expect(true).to.equal(true);
-        next();
-    });
+  this.Then(/^it should expose the correct global variables$/, function(next) {
+    expect(protractor).to.exist;
+    expect(browser).to.exist;
+    expect(by).to.exist;
+    expect(element).to.exist;
+    expect($).to.exist;
+    next();
+  });
 
-    this.Then(/^it should expose the correct global variables$/, function(next) {
-        expect(protractor).to.exist;
-        expect(browser).to.exist;
-        expect(by).to.exist;
-        expect(element).to.exist;
-        expect($).to.exist;
-        next();
-    });
-
-    this.Then(/the title should equal "([^"]*)"$/, function(text, next) {
-        expect(browser.getTitle()).to.eventually.equal(text).and.notify(next);
-    });
-
+  this.Then(/the title should equal "([^"]*)"$/, function(text, next) {
+    expect(browser.getTitle()).to.eventually.equal(text).and.notify(next);
+  });
 };

--- a/spec/cucumber/stepDefinitionsV2.js
+++ b/spec/cucumber/stepDefinitionsV2.js
@@ -1,0 +1,16 @@
+var path = require('path');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+var {defineSupportCode} = require(path.join(__dirname, '..', '..', 'lib', 'cucumberLoader')).load();
+
+defineSupportCode(({Given, Then}) => {
+  Given(/^I go on(?: the website)? "([^"]*)"$/, function(url) {
+    return browser.get(url);
+  });
+
+  Then(/the title should equal "([^"]*)"$/, function(text) {
+    return expect(browser.getTitle()).to.eventually.equal(text);
+  });
+});

--- a/spec/cucumber2Conf.js
+++ b/spec/cucumber2Conf.js
@@ -1,0 +1,16 @@
+var env = require('./environment.js');
+
+exports.config = {
+  baseUrl: env.baseUrl,
+  seleniumAddress: env.seleniumAddress,
+  framework: 'custom',
+  frameworkPath: '../index.js',
+  capabilities: env.capabilities,
+  specs: ['cucumber/*.feature'],
+
+  cucumberOpts: {
+    require: 'cucumber/**/stepDefinitionsV2.js',
+    tags: '@cucumber2',
+    strict: true
+  }
+};

--- a/spec/multidep.js
+++ b/spec/multidep.js
@@ -1,0 +1,9 @@
+var path = require('path');
+var cucumberConf = require(path.join(__dirname, '..', 'package.json')).cucumberConf;
+
+module.exports = {
+  path: 'spec/multidep_modules',
+  versions: {
+    cucumber: [cucumberConf.version1, cucumberConf.version2]
+  }
+};


### PR DESCRIPTION
This should be backwards compatible with the current version of cucumber. I haven't looked at what it would take to run tests against different versions of cucumber, but that would be ideal.

Cucumber 2 introduces a few breaking changes that we have to account for...

  * different way to invoke the cli and it changed from callback to promise based
  * the objects on the event handler no longer have `getPropertyName` functions, they are just `propertyNames` exposed
  * registering event handlers is now done through `defineSupportCode` instead of using `this`
  * tag format changed to use [cucumber-tag-expressions](https://docs.cucumber.io/tag-expressions/)

This should close #64 and should close #55 as well